### PR TITLE
feat: Implement changes to make it compatible with Thunderbird

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,0 +1,63 @@
+GEM
+  remote: https://rubygems.org/
+  specs:
+    base64 (0.2.0)
+    coderay (1.1.3)
+    diff-lcs (1.5.1)
+    gpgme (2.0.24)
+      mini_portile2 (~> 2.7)
+    method_source (1.1.0)
+    mini_portile2 (2.8.7)
+    multi_json (1.15.0)
+    mustermann (3.0.2)
+      ruby2_keywords (~> 0.0.1)
+    nio4r (2.7.3)
+    pry (0.14.2)
+      coderay (~> 1.1)
+      method_source (~> 1.0)
+    puma (6.4.2)
+      nio4r (~> 2.0)
+    rack (2.2.9)
+    rack-protection (3.2.0)
+      base64 (>= 0.1.0)
+      rack (~> 2.2, >= 2.2.4)
+    rspec (3.13.0)
+      rspec-core (~> 3.13.0)
+      rspec-expectations (~> 3.13.0)
+      rspec-mocks (~> 3.13.0)
+    rspec-core (3.13.0)
+      rspec-support (~> 3.13.0)
+    rspec-expectations (3.13.2)
+      diff-lcs (>= 1.2.0, < 2.0)
+      rspec-support (~> 3.13.0)
+    rspec-mocks (3.13.1)
+      diff-lcs (>= 1.2.0, < 2.0)
+      rspec-support (~> 3.13.0)
+    rspec-support (3.13.1)
+    ruby2_keywords (0.0.5)
+    sinatra (3.2.0)
+      mustermann (~> 3.0)
+      rack (~> 2.2, >= 2.2.4)
+      rack-protection (= 3.2.0)
+      tilt (~> 2.0)
+    sinatra-contrib (3.2.0)
+      multi_json (>= 0.0.2)
+      mustermann (~> 3.0)
+      rack-protection (= 3.2.0)
+      sinatra (= 3.2.0)
+      tilt (~> 2.0)
+    tilt (2.4.0)
+
+PLATFORMS
+  x86_64-linux
+
+DEPENDENCIES
+  gpgme
+  pry
+  puma
+  rspec
+  sinatra
+  sinatra-contrib
+
+BUNDLED WITH
+   2.4.10

--- a/README.md
+++ b/README.md
@@ -65,11 +65,15 @@ keys on Linux, the most common way to manage keys with YAKS is the following:
 
 ## Thunderbird
 
-As of release 78, Thunderbird provides an internal tool to manage GPG keys
-which works only with servers using the [WKD/WKS protocol][wkd-wks-protocol].
+As of release 115, Thunderbird's internal tool to manage GPG keys supports the
+HKP protocol, that this server implements. To use your server you have to set
+the  `mail.openpgp.keyserver_list` configuration parameter in Thunderbird to the
+server address, e.g.: hkps://yaks.address.com.
 
-You have to manually download the desired key from the YAKS server, export it
-and then import it into Thunderbird, e.g.:
+Earlier versions of Thunderbird only support servers using the
+[WKD/WKS protocol][wkd-wks-protocol]. In this case you have to manually download
+the desired key from the YAKS server, export it and then import it into
+Thunderbird, e.g.:
 
 ```
 $ gpg --keyserver hkps://yaks.address.com --export --armor --output bence.asc \

--- a/lib/app.rb
+++ b/lib/app.rb
@@ -50,7 +50,7 @@ get '/pks/lookup' do
     headers \
       'Content-Type' => 'application/pgp-keys; charset=utf-8',
       'Content-Disposition' => 'attachment; filename=openpgpkey.asc'
-    keys.first.export.read
+    keys.first.export(:armor => true).read
   when /^v?index$/
     keys = GPGME::Key.find(:public, params[:search])
     status(404) && return unless keys.size > 0

--- a/lib/app.rb
+++ b/lib/app.rb
@@ -52,7 +52,9 @@ get '/pks/lookup' do
       'Content-Disposition' => 'attachment; filename=openpgpkey.asc'
     keys.first.export(:armor => true).read
   when /^v?index$/
-    keys = GPGME::Key.find(:public, params[:search])
+    search = params[:search]
+    search = %{<#{search}>} if params[:exact] == 'on'
+    keys = GPGME::Key.find(:public, search)
     status(404) && return unless keys.size > 0
     headers 'Content-Type' => 'text/plain; charset=utf-8'
 


### PR DESCRIPTION
Thunderbird 115 added support of HKP keyservers. This PR implement the changes necessary to make this project compatible with Thunderbird.